### PR TITLE
Invoke pre-commit-poirot from pre-commit, add opts

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -139,24 +139,22 @@ To set up a pre-commit hook for a particular repository, first install Poirot an
 
 .. code:: bash
 
-    curl https://raw.githubusercontent.com/DCgov/poirot/master/pre-commit-poirot > .git/hooks/pre-commit
-    chmod +x .git/hooks/pre-commit
+    curl https://raw.githubusercontent.com/DCgov/poirot/master/pre-commit-poirot > .git/hooks/pre-commit-poirot
+    chmod +x .git/hooks/pre-commit-poirot
+    echo '.git/hooks/pre-commit-poirot -f "" -p ""' >> .git/hooks/pre-commit
+    chmod +x ~/.git_template/hooks/pre-commit
 
-This installs the pre-commit hook script for your repository and makes it executable.
+The :code:`-f` and :code:`-p` in the second to last line are flags for patterns folder and a comma-separated list of pattern files, respectively. These let you use patterns other than the default, if you would like, by providing their absolute path or URL.
 
-If you would like to use patterns other than the default, run:
+For example, you could change the flag values to :code:`-f "/Users/myusername/Documents/poirot-patterns" -p "https://github.com/DCgov/poirot-patterns/blob/master/financial.txt, https://github.com/DCgov/poirot-patterns/blob/master/id.txt"`.
+
+You can either edit that line before you run it, or edit it after with:
 
 .. code:: bash
 
     vim .git/hooks/pre-commit
 
-This is easiest to manage if you put all the pattern files in one folder on your computer. My advice is to fork the `poirot-patterns repository <https://github.com/dcgov/poirot-patterns/>`_ and download it to your computer.
-
-Then edit the following line, so that it gives the absolute path to that folder within quotes:
-
-.. code:: bash
-
-    patterns_folder=""
+My advice is to fork the `poirot-patterns repository <https://github.com/dcgov/poirot-patterns/>`_ and download it to your computer. Then add the absolute path to that folder as the :code:`-f` flag.
 
 If you go ahead with setting up a patterns folder, then you can easily add, delete, or modify the pattern files without having to keep re-editing the commit hook.
 
@@ -174,24 +172,16 @@ To set a Poirot pre-commit hook for all your new repositories, you can add it to
 
     mkdir -p ~/.git_template/hooks
     git config --global init.templatedir '~/.git_template'
-    curl https://raw.githubusercontent.com/DCgov/poirot/master/pre-commit-poirot > ~/.git_template/hooks/pre-commit
+    curl https://raw.githubusercontent.com/DCgov/poirot/master/pre-commit-poirot > ~/.git_template/hooks/pre-commit-poirot
+    chmod +x ~/.git_template/hooks/pre-commit-poirot
+    echo '.git/hooks/pre-commit-poirot -f "" -p ""' >> ~/.git_template/hooks/pre-commit
     chmod +x ~/.git_template/hooks/pre-commit
 
-For existing repositories, you can either follow the instructions above or re-run :code:`git init` in the repo. Running :code:`git init` will not overwrite things that are already there. It will only add new template files (e.g. this hook).
+As in the `Single Repositories <https://github.com/DCgov/poirot#for-a-single-repository>`_ case, the :code:`-f` and :code:`-p` flags in the second to last line will let you use pattern files other than the default. If you don't care about that, you can run it as is.
+
+For existing repositories, you can re-run :code:`git init` in the repo. Running :code:`git init` will not overwrite things that are already there. It will only add new template files (e.g. this hook).
 
 As in the above section on `Single Repositories <https://github.com/DCgov/poirot#for-a-single-repository>`_, I recommend that you start out by setting up a patterns folder on your computer. You can fork and download the `poirot-patterns repository <https://github.com/dcgov/poirot-patterns/>`_ to get started.
-
-Then run:
-
-.. code:: bash
-
-    vim ~/.git_template/hooks/pre-commit
-
-And edit the following line, so that it gives the absolute path to that folder within quotes:
-
-.. code:: bash
-
-    patterns_folder=""
 
 Using a patterns folder avoids most instances that would make you want to make subsequent edits to your global pre-commit hook.
 

--- a/pre-commit-poirot
+++ b/pre-commit-poirot
@@ -24,14 +24,7 @@ function run_poirot()
 
     # Run Poirot
     echo "Running Poirot..."
-    remote_url=$(git config --get remote.origin.url)
 
-    # EDIT THIS LINE TO GIVE THE ABSOLUTE PATH TO YOUR PATTERNS FOLDER, E.G.:
-    # patterns_folder="/Users/myusername/Documents/poirot-patterns"
-
-    patterns_folder=""
-
-    patterns=""
     if [ -n "$patterns_folder" ]; then
         echo "Pattern files:"
         for pattern_file in "$patterns_folder"/*.txt
@@ -63,6 +56,25 @@ function run_poirot()
         exit 0
     fi
 }
+
+patterns_folder=""
+patterns=""
+
+# Read in optional patterns folder and patterns files
+while getopts "f:p:" opt; do
+  case $opt in
+    f)
+      patterns_folder="$OPTARG"
+      ;;
+    p)
+      patterns="$OPTARG"
+      ;;
+    \?)
+      echo "Invalid option: -$OPTARG" >&2
+      exit 1
+      ;;
+  esac
+done
 
 setup_poirot || setup_failure
 run_poirot


### PR DESCRIPTION
Call pre-commit-poirot from pre-commit hook so as to not overwrite
existing pre-commit hooks.

Adds -p and -f as pre-commit-poirot flags for patterns folders and
files.

Fixes #32
Fixes #31

Thanks to @stvnrlly for the issue
